### PR TITLE
make a link to pdf instead of to a raw folder

### DIFF
--- a/_posts/s2/2018-09-07-software-engineering.md
+++ b/_posts/s2/2018-09-07-software-engineering.md
@@ -46,7 +46,7 @@ All the material for this course is available on Moodle.
 
 ### Grading ###
 
- - Project (40%) - [2020]({% include link-asset asset="project-m1/"%} )
+ - Project (40%) - [2020]({% include link-asset asset="project-m1/project.pdf"%} )
  - Final Exam (60%)
 
 ### Resources ###


### PR DESCRIPTION
Merci, j'ai pu tester mais du coup, ce n'est pas du tout ce que j'espérais.

Je pensais que le md dans les assets allait être transformé en html aussi mais apparemment il n'y a que les posts que sont transformés, pas les assets. C'est ce que j'ai cru comprendre d'un tuto jekyll.

Du coup je n'ai pas voulu changer la structure de _posts/s2 qui semble épurée et j'ai fait un lien vers un fichier pdf. C'est dommage, j'avais fait un project.md pour faciliter l'intégration dans github mais apparemment ça ne sert à rien :(

Moodle n'aime pas non plus les .md d'ailleurs.